### PR TITLE
Changes to allow modal windows to have an owner/parent.

### DIFF
--- a/examples/gui/filedialog/filedialog.lpi
+++ b/examples/gui/filedialog/filedialog.lpi
@@ -1,7 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="7"/>
+    <Version Value="9"/>
     <General>
       <Flags>
         <SaveOnlyProjectUnits Value="True"/>
@@ -9,11 +9,13 @@
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <MainUnit Value="0"/>
-      <TargetFileExt Value=""/>
     </General>
     <VersionInfo>
-      <ProjectVersion Value=""/>
+      <StringTable ProductVersion=""/>
     </VersionInfo>
+    <BuildModes Count="1">
+      <Item1 Name="default" Default="True"/>
+    </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
       <IncludeFileFilter Value="*.(pas|pp|inc|lfm|lpr|lrs|lpi|lpk|sh|xml)"/>
@@ -34,16 +36,18 @@
       <Unit0>
         <Filename Value="filedialog.lpr"/>
         <IsPartOfProject Value="True"/>
-        <UnitName Value="filedialog"/>
       </Unit0>
     </Units>
   </ProjectOptions>
   <CompilerOptions>
-    <Version Value="8"/>
+    <Version Value="11"/>
+    <Parsing>
+      <SyntaxOptions>
+        <UseAnsiStrings Value="False"/>
+      </SyntaxOptions>
+    </Parsing>
     <Other>
-      <CustomOptions Value="-FUunits
-"/>
-      <CompilerPath Value="$(CompPath)"/>
+      <CustomOptions Value="-FUunits"/>
     </Other>
   </CompilerOptions>
 </CONFIG>

--- a/examples/gui/filedialog/filedialog.lpr
+++ b/examples/gui/filedialog/filedialog.lpr
@@ -118,7 +118,7 @@ procedure TMainForm.btnOpenFileClick(Sender: TObject);
 var
   dlg: TfpgFileDialog;
 begin
-  dlg := TfpgFileDialog.Create(nil);
+  dlg := TfpgFileDialog.Create(Self);
   try
     // defines 3 filters (All Files, Object Pascal and Lazarus Project)
     dlg.Filter := 'All Files (*)|*|Object Pascal (*.pas;*.lpr;*.pp)|*.pas;*.lpr;*.pp|Lazarus Project (*.lpi)|*.lpi';

--- a/examples/gui/modalforms/modalforms.lpi
+++ b/examples/gui/modalforms/modalforms.lpi
@@ -1,20 +1,21 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <PathDelim Value="/"/>
-    <Version Value="6"/>
+    <Version Value="9"/>
     <General>
       <Flags>
         <SaveOnlyProjectUnits Value="True"/>
+        <LRSInOutputDirectory Value="False"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <MainUnit Value="0"/>
-      <IconPath Value="./"/>
-      <TargetFileExt Value=""/>
     </General>
     <VersionInfo>
-      <ProjectVersion Value=""/>
+      <StringTable ProductVersion=""/>
     </VersionInfo>
+    <BuildModes Count="1">
+      <Item1 Name="default" Default="True"/>
+    </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
       <IncludeFileFilter Value="*.(pas|pp|inc|lfm|lpr|lrs|lpi|lpk|sh|xml)"/>
@@ -35,15 +36,18 @@
       <Unit0>
         <Filename Value="modalforms.lpr"/>
         <IsPartOfProject Value="True"/>
-        <UnitName Value="modalforms"/>
       </Unit0>
     </Units>
   </ProjectOptions>
   <CompilerOptions>
-    <Version Value="8"/>
+    <Version Value="11"/>
+    <Parsing>
+      <SyntaxOptions>
+        <UseAnsiStrings Value="False"/>
+      </SyntaxOptions>
+    </Parsing>
     <Other>
       <CustomOptions Value="-FUunits"/>
-      <CompilerPath Value="$(CompPath)"/>
     </Other>
   </CompilerOptions>
 </CONFIG>

--- a/examples/gui/modalforms/modalforms.lpr
+++ b/examples/gui/modalforms/modalforms.lpr
@@ -99,7 +99,7 @@ procedure TForm1.btnOpenForm2Click(Sender: TObject);
 var
   frm: TForm2;
 begin
-  frm := TForm2.Create(nil);
+  frm := TForm2.Create(Self);
   try
     frm.ShowModal;
     writeln('Form2: This should only appear after the form closes.');
@@ -113,6 +113,7 @@ end;
 constructor TForm1.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+  Visible:=False;
   WindowTitle := 'Form1';
   Sizeable := False;
   SetPosition(150, 150, 200, 200);
@@ -144,7 +145,7 @@ procedure TMainForm.btnOpenForm1Click(Sender: TObject);
 var
   frm: TForm1;
 begin
-  frm := TForm1.Create(nil);
+  frm := TForm1.Create(Self);
   try
     frm.ShowModal;
     writeln('Form1: This should only appear after the form closes.');

--- a/src/corelib/fpg_main.pas
+++ b/src/corelib/fpg_main.pas
@@ -2015,10 +2015,13 @@ begin
 
   FModalForWin := nil;
 
-  if (AOwner <> nil) and (AOwner is TfpgWindow) then
-    FWindowType   := wtChild
-  else
-    FWindowType   := wtWindow;
+  if not (FWindowType in [wtModalForm, wtPopup]) then
+  begin
+    if (AOwner <> nil) and (AOwner is TfpgWindow) then
+      FWindowType   := wtChild
+    else
+      FWindowType   := wtWindow;
+  end;
 
   FCanvas := CreateCanvas;
 end;

--- a/src/corelib/fpg_widget.pas
+++ b/src/corelib/fpg_widget.pas
@@ -503,7 +503,7 @@ begin
 
   inherited Create(AOwner);
 
-  if (AOwner <> nil) and (AOwner is TfpgWidget) then
+  if (AOwner <> nil) and (AOwner is TfpgWidget) and (not (WindowType in [wtModalForm, wtPopup])) {and not InheritsFrom(TfpgForm)} then
   begin
     Parent := TfpgWidget(AOwner);
     FTabOrder := AOwner.ComponentCount;

--- a/src/corelib/x11/fpg_x11.pas
+++ b/src/corelib/x11/fpg_x11.pas
@@ -2271,11 +2271,13 @@ var
   WMHints: PXWMHints;
   prop: TAtom;
   mwmhints: TMWMHints;
+  IsToplevel: Boolean;
 begin
   if HandleIsValid then
     Exit; //==>
 
-  if AParent <> nil then
+  IsToplevel := (AParent = nil) or (FWindowType in [wtModalForm, wtPopup]);
+  if not IsToplevel then
     pwh := TfpgX11Window(AParent).WinHandle
   else
     pwh := xapplication.RootWindow;
@@ -2314,7 +2316,7 @@ begin
   FWinHandle := wh;
   FBackupWinHandle := wh;
 
-  if AParent = nil then // is a toplevel window
+  if IsToplevel then // is a toplevel window
   begin
     { setup a window icon }
     IconPixMap := XCreateBitmapFromData(fpgApplication.Display, FWinHandle,
@@ -2400,11 +2402,13 @@ begin
   // for modal windows, this is necessary
   if FWindowType = wtModalForm then
   begin
-    if Parent = nil then
+    if IsToplevel then
     begin
       lmwh := 0;
       if fpgApplication.PrevModalForm <> nil then
         lmwh := TfpgX11Window(fpgApplication.PrevModalForm).WinHandle
+      {else if AParent <> nil then
+        lmwh := TfpgX11Window(AParent).WinHandle}
 { 2011-03-24: Graeme Geldenhuys
   I commented code this code because it caused more problems that it solved
   when multiple modal dialogs or prompts are shown in succession.

--- a/src/gui/fpg_dialogs.pas
+++ b/src/gui/fpg_dialogs.pas
@@ -577,6 +577,8 @@ end;
 
 constructor TfpgBaseDialog.Create(AOwner: TComponent);
 begin
+  // WindowType must be set before inherited or our parent property will be set
+  WindowType:=wtModalForm;
   inherited Create(AOwner);
   Width     := 500;
   Height    := 400;

--- a/src/gui/fpg_form.pas
+++ b/src/gui/fpg_form.pas
@@ -342,6 +342,8 @@ function TfpgBaseForm.ShowModal: TfpgModalResult;
 var
   lCloseAction: TCloseAction;
 begin
+  if HasHandle and (FWindowType <> wtModalForm) then
+    HandleHide;
   FWindowType := wtModalForm;
   fpgApplication.PushModalForm(self);
   ModalResult := mrNone;

--- a/src/gui/fpg_menu.pas
+++ b/src/gui/fpg_menu.pas
@@ -1341,6 +1341,7 @@ end;
 
 constructor TfpgPopupMenu.Create(AOwner: TComponent);
 begin
+  FWindowType:=wtPopup;
   inherited Create(AOwner);
   FMargin     := 3;
   FTextMargin := 3;


### PR DESCRIPTION
TfpgBaseDialog descendants will not have Parent assigned, only Owner. TfpgBaseForm descendants will behave the same when Parent is set but if ShowModal is used it will become a toplevel window. If a new class is created based on TfpgForm that is intended to be a modal form then set WindowType := wtModalForm before calling inherited Create(AOwner);