### PR TITLE
Set OwnsImage to true when an image is set

### DIFF
--- a/src/gui/fpg_panel.pas
+++ b/src/gui/fpg_panel.pas
@@ -1075,6 +1075,7 @@ begin
   if FOwnsImage and Assigned(FImage) then
     FImage.Free;
   FImage := AValue;
+  OwnsImage:= True;
   Repaint;
 end;
 


### PR DESCRIPTION
Signed-off-by: Jean-Marc Levecque jmarc.levecque@bbox.fr

OwnsImage was never set to true and the image was not freed in imagepanel.destroy.
This is to solve the issue.
