### PR TITLE
Added scaling for Windows fonts

### DIFF
--- a/src/corelib/fpg_base.pas
+++ b/src/corelib/fpg_base.pas
@@ -28,11 +28,15 @@ unit fpg_base;
 interface
 
 uses
+  {$IFDEF WINDOWS}Windows,{$ENDIF}
   Classes,
   SysUtils,
   fpg_impl,
   syncobjs, // TCriticalSection usage
   variants, contnrs;
+
+function ScaleX(const SizeX, FromDPI: integer): integer;
+function ScaleY(const SizeY, FromDPI: integer): integer;
 
 type
   TfpgCoord       = integer;     // we might use floating point coordinates in the future...
@@ -798,6 +802,19 @@ const
   NoDefault = $80000000;
   tkPropsWithDefault = [tkInteger, tkChar, tkSet, tkEnumeration];
 
+function ScaleX(const SizeX, FromDPI: integer): integer;
+begin
+  {$IFDEF WINDOWS}
+  Result := MulDiv(SizeX, fpgApplication.Screen_dpi_x, FromDPI);
+  {$ENDIF}
+end;
+
+function ScaleY(const SizeY, FromDPI: integer): integer;
+begin
+  {$IFDEF WINDOWS}
+  Result := MulDiv(SizeY, fpgApplication.Screen_dpi_y, FromDPI);
+  {$ENDIF}
+end;
 
 function KeycodeToText(AKey: Word; AShiftState: TShiftState): string;
 
@@ -3241,7 +3258,11 @@ begin
   end;
 end;
 
-
+initialization
+{$IFDEF WINDOWS}
+FPG_DEFAULT_FONT_DESC:= 'Arial-'+IntToStr(ScaleY(8, 96))+':antialias=true';
+FPG_DEFAULT_FIXED_FONT_DESC:= 'Courier New-'+IntToStr(ScaleY(10, 96));
+{$ENDIF}
 
 end.
 

--- a/src/corelib/fpg_main.pas
+++ b/src/corelib/fpg_main.pas
@@ -2093,8 +2093,8 @@ begin
   fpgSetNamedFont('Edit1', FPG_DEFAULT_FONT_DESC);
   fpgSetNamedFont('Edit2', FPG_DEFAULT_FIXED_FONT_DESC);
   fpgSetNamedFont('List', FPG_DEFAULT_FONT_DESC);
-  fpgSetNamedFont('Grid', FPG_DEFAULT_SANS + '-9');
-  fpgSetNamedFont('GridHeader', FPG_DEFAULT_SANS + '-9:bold');
+  fpgSetNamedFont('Grid', FPG_DEFAULT_SANS + '-' + IntToStr(ScaleY(9, 96)));
+  fpgSetNamedFont('GridHeader', FPG_DEFAULT_SANS + '-' + IntToStr(ScaleY(9, 96)) + ':bold');
   fpgSetNamedFont('Menu', FPG_DEFAULT_FONT_DESC);
   fpgSetNamedFont('MenuAccel', FPG_DEFAULT_FONT_DESC + ':underline');
   fpgSetNamedFont('MenuDisabled', FPG_DEFAULT_FONT_DESC);


### PR DESCRIPTION
Hi, I've noticed that the default font settings does not include scaling for High DPI modes under Windows.

I've added:
- ScaleX: scales horizontally a value depending on DPI settings
- ScaleY: scales vertically a value depending on DPI settings

These need to go in fpg_base unit. I've scaled in the same unit the default values of fonts, as you can see. Also must scale other font settings in the fgp_main unit.

This helps to see correctly the application under different DPI modes. Please read http://wiki.freepascal.org/High_DPI

Also ScaleX and ScaleY are usefull to scale form controls, not only the fonts. In a WIP application I'm using both as is:

```
    { Scale Form and Controls }
    Self.Width := ScaleX(Width, 96);
    Self.Height := ScaleY(Height, 96);

    for i := 0 to Self.ComponentCount - 1 do
    begin
      if Self.Components[i] is TFPGWidget then
      begin
        with TFPGWidget(Self.Components[i]) do
        begin
          Left := ScaleX(Left, 96);
          Top := ScaleY(Top, 96);
          Width := ScaleX(Width, 96);
          Height := ScaleY(Height, 96);
        end;
      end;
    end;
```
