### PR TITLE
Fixes WinCE compilation errors

### DIFF
--- a/src/corelib/gdi/fpg_gdi.pas
+++ b/src/corelib/gdi/fpg_gdi.pas
@@ -38,7 +38,8 @@ unit fpg_gdi;
 
 {$IFDEF WINCE}
   // WinCE doesn't have DND support
-  {$undefine HAS_DND}
+  {$UNDEF HAS_DND} //there is no $undefine compiler directive
+  {$UNDEF HAS_OPACITY} //too many bugs for WinCE
 {$ENDIF}
 
 interface
@@ -216,7 +217,9 @@ type
     procedure   DoSetWindowTitle(const ATitle: string); override;
     procedure   DoSetMouseCursor; override;
     //procedure   DoDragStartDetected; override;
+    {$IFDEF HAS_OPACITY}
     procedure   SetWindowOpacity(AValue: Single); override;
+    {$ENDIF}
     function    GetWindowState: TfpgWindowState; override;
     property    WinHandle: TfpgWinHandle read FWinHandle;
   public
@@ -320,10 +323,12 @@ type
   TfpgGDIDrop = class(TfpgDropBase)
   private
     FSource: IDataObject;
-    FDropAction: DWORD; // effect
+    FDropAction: DWORD; // effect              
+    {$IFDEF HAS_DND} //Fixed WinCE compilation errors
     procedure   LoadMimeTypes;
     procedure   ReadDropData;
     function    ActionAsOLEEffect: TfpgOLEDragDropEffect;
+    {$ENDIF}
   protected
     function    GetDropAction: TfpgDropAction; override;
     procedure   SetDropAction(AValue: TfpgDropAction); override;
@@ -1317,6 +1322,7 @@ end;
 
 { TfpgGDIDrop }
 
+{$IFDEF HAS_DND}//Fixes WinCE compilation errors
 procedure TfpgGDIDrop.LoadMimeTypes;
 var
   lMimeList: TStringList;
@@ -1371,6 +1377,7 @@ begin
     daAsk:    Result := deCopy; //?
   end;
 end;
+{$ENDIF}
 
 function TfpgGDIDrop.GetDropAction: TfpgDropAction;
 begin
@@ -2169,6 +2176,7 @@ begin
   SetCursor(hc);
 end;
 
+{$IFDEF HAS_OPACITY}
 procedure TfpgGDIWindow.SetWindowOpacity(AValue: Single);
 var
  NeedsLayered: Boolean;
@@ -2208,6 +2216,7 @@ begin
   end;
 
 end;
+{$ENDIF}
 
 (*  // TODO: disabled for AlienWindows branch. We should fine a solution later.
 procedure TfpgGDIWindow.DoDragStartDetected;


### PR DESCRIPTION
There was an "$undefine" instead of "$undef", and the opacity settings are not functioning properly with WinCE, so the compiler variable "HAS_OPACITY" has also been undefined for the WinCE platform.