### PR TITLE
File dialog sizing alterations

### DIFF
--- a/src/gui/fpg_dialogs.pas
+++ b/src/gui/fpg_dialogs.pas
@@ -205,6 +205,7 @@ type
   public
     FileName: string;
     constructor Create(AOwner: TComponent); override;
+    procedure   AfterConstruction; override;
     destructor  Destroy; override;
     function    RunOpenFile: boolean;
     function    RunSaveFile: boolean;
@@ -1335,6 +1336,39 @@ begin
   btnCancel.Top   := Height - btnCancel.Height - FSpacing;
   btnOK.Left      := btnCancel.Left - FDefaultButtonWidth - 6;
   btnOK.Top       := btnCancel.Top;
+end;
+
+{ adjust layout for small screens if needed }
+procedure TfpgFileDialog.AfterConstruction;
+var
+	w, h: integer;
+	nl, nt, nw, nh: integer;
+begin
+  inherited AfterConstruction;
+  w:=fpgApplication.ScreenWidth;
+  h:=fpgApplication.ScreenHeight;
+  nw:=width;
+  nh:=height;
+  nl:=left;
+  nt:=top;
+  if width>w then begin
+    if MinWidth<w then MinWidth:=w;
+    nl:=0;
+    nw:=w;
+  end;
+  if height>h then begin
+    if MinHeight>h then begin
+      MinHeight:=h;
+      { if height challenged we can hide the pnlFileInfo with little reduction
+        in usability }
+      grid.height:=pnlFileInfo.top+pnlFileInfo.height-grid.top;
+      pnlFileInfo.visible:=false;
+    end;
+    nt:=0;
+    nh:=h;
+  end;
+  if (nl<>left) and (nt<>top) then WindowPosition:=wpUser;
+  if (nw<>width) and (nh<>height) then SetPosition(nl, nt, nw, nh);
 end;
 
 destructor TfpgFileDialog.Destroy;

--- a/src/gui/fpg_dialogs.pas
+++ b/src/gui/fpg_dialogs.pas
@@ -81,7 +81,7 @@ const
 type
 
   TfpgMessageBox = class(TfpgForm)
-  private
+  protected
     {@VFD_HEAD_BEGIN: MessageBox}
     FButton: TfpgButton;
     {@VFD_HEAD_END: MessageBox}
@@ -123,7 +123,7 @@ type
 
 
   TfpgFontSelectDialog = class(TfpgBaseDialog)
-  private
+  protected
     FSampleText: string;
     FMode: Byte;    // 1 - Normal Fonts;  2 - Alias Fonts
     lblLabel1: TfpgLabel;
@@ -145,7 +145,6 @@ type
     procedure   CreateFontList;
     procedure   CreateFontAliasList;
     procedure   SetupUI(AMode: Byte);
-  protected
     function    GetFontDesc: string;
     procedure   SetFontDesc(Desc: string);
     procedure   SetupCaptions; override;
@@ -156,7 +155,7 @@ type
 
 
   TfpgFileDialog = class(TfpgBaseDialog)
-  private
+  protected
     chlDir: TfpgComboBox;
     grid: TfpgFileGrid;
     btnUpDir: TfpgButton;
@@ -199,7 +198,6 @@ type
     function    CreatePopupMenu: TfpgPopupMenu;
     procedure   BookmarkItemClicked(Sender: TObject);
     procedure   ShowConfigureBookmarks;
-  protected
     procedure   HandleKeyPress(var keycode: word; var shiftstate: TShiftState; var consumed: boolean); override;
     procedure   btnOKClick(Sender: TObject); override;
     procedure   SetCurrentDirectory(const ADir: string);
@@ -1678,4 +1676,3 @@ end;
 
 
 end.
-


### PR DESCRIPTION
Although git is like an additional appendage to me I'm still a relative virgin with github. Apparently this request will encompass the previous one with the visibility changes and I haven't figured out how to limit it. These are the alterations I made to allow the file dialog to work on my PocketCHIP (480x272). This will automatically scale down the size of form when the screen size is smaller than the original design size. It also hides the file panel and extends the file grid into its space when the display is height challenged. After I figure out the form life cycle and event handling I'd like to make this change and few other visual re-arrangements dynamically, based on how the user might resize the form as well as screen limitations... but DB and Android are my prime focuses now.