### PR TITLE
Refactor TfpgDrag.GetSource

### DIFF
--- a/src/corelib/fpg_base.pas
+++ b/src/corelib/fpg_base.pas
@@ -866,6 +866,8 @@ type
     FSource: TfpgWidgetBase;
     FDragging: Boolean;
     FMimeData: TfpgMimeDataBase;
+  protected
+    function	GetSource: TfpgWidgetBase; virtual;
   public
     constructor Create(ASource: TfpgWidgetBase);
     destructor  Destroy; override;
@@ -4359,6 +4361,11 @@ begin
   inherited Destroy;
 end;
 
+function TfpgDragBase.GetSource: TfpgWidgetBase;
+begin
+  Result := FSource;
+end;
+
 
 { TfpgBaseTimer }
 
@@ -4425,4 +4432,3 @@ end;
 
 
 end.
-

--- a/src/corelib/fpg_main.pas
+++ b/src/corelib/fpg_main.pas
@@ -379,7 +379,6 @@ type
     procedure   MsgMouseMove(var msg: TfpgMessageRec); message FPGM_MOUSEMOVE;
   protected
     FPreviewWin: TfpgWidgetBase; // TfpgDNDWindow
-    function    GetSource: TfpgWidgetBase; reintroduce;
     procedure   DoOnPaintPreview(ACanvas: TfpgCanvas);
   public
     constructor Create(ASource: TfpgWidgetBase);
@@ -3146,11 +3145,6 @@ begin
 end;
 
 
-function TfpgDrag.GetSource: TfpgWidgetBase;
-begin
-  Result := TfpgWidgetBase(inherited GetSource);
-end;
-
 procedure TfpgDrag.DoOnPaintPreview(ACanvas: TfpgCanvas);
 begin
   if Assigned(FOnPaintPreview) then
@@ -3210,4 +3204,3 @@ finalization
   FinalizeDebugOutput;
 
 end.
-

--- a/src/corelib/gdi/fpg_gdi.pas
+++ b/src/corelib/gdi/fpg_gdi.pas
@@ -312,8 +312,6 @@ type
   TfpgGDIDrag = class(TfpgDragBase)
   private
     function    StringToHandle(const AString: TfpgString): HGLOBAL;
-  protected
-    function    GetSource: TfpgWidgetBase; virtual;
   public
     destructor  Destroy; override;
     function    Execute(const ADropActions: TfpgDropActions; const ADefaultAction: TfpgDropAction=daCopy): TfpgDropAction; override;
@@ -3395,11 +3393,6 @@ begin
   Result := dest;
 end;
 
-function TfpgGDIDrag.GetSource: TfpgWidgetBase;
-begin
-  Result := FSource;
-end;
-
 destructor TfpgGDIDrag.Destroy;
 begin
   {$IFDEF DND_DEBUG}
@@ -3676,4 +3669,3 @@ finalization
 {$ENDIF}
 
 end.
-

--- a/src/corelib/x11/fpg_x11.pas
+++ b/src/corelib/x11/fpg_x11.pas
@@ -417,8 +417,6 @@ type
     procedure   HandleSelectionRequest(ev: TXEvent);
     procedure   QueueFree;
     procedure   DropTimeout(Sender: TObject);
-  protected
-    function    GetSource: TfpgWidgetBase; virtual;
   public
     destructor  Destroy; override;
     function    Execute(const ADropActions: TfpgDropActions; const ADefaultAction: TfpgDropAction = daCopy): TfpgDropAction; override;
@@ -4380,11 +4378,6 @@ begin
   fpgPostMessage(Self, Self, FPGM_KILLME);
 end;
 
-function TfpgX11Drag.GetSource: TfpgWidgetBase;
-begin
-  Result := FSource;
-end;
-
 destructor TfpgX11Drag.Destroy;
 begin
   {$IFDEF DNDDEBUG}
@@ -4521,4 +4514,3 @@ finalization
 {$ENDIF}
 
 end.
-


### PR DESCRIPTION
Hey Graeme!

Been building up a skeleton to fill with Android UI components. I've been testing it to make sure it compiles, although it does nothing. This has helped me make sure i have all of the abstracts declared, so I know how to proceed. Anyhow in the process I ran across GetSource() being needed and all of the implementations did the same thing. So I refactored it and added it to TfpgDragBase. It can be overridden if needed.

Let me know if this is a bad idea for some reason. I'm still getting familiar with the guts.

I'll probably offer up some abstract declarations later. Things that are obviously required but weren't declared in the base classes. I'll even try a non-GitHub pull request next time.

THX!