### PR TITLE
Fix script for examples compilation

### DIFF
--- a/examples/apps/compileall.sh
+++ b/examples/apps/compileall.sh
@@ -6,11 +6,11 @@ do
   PROJECT=`basename $f`
   LPRNAME=`basename $PROJECT .lpr`
   echo Doing $LPRNAME in $DIR
-  cd $DIR
+  pushd $DIR > /dev/null
   if [ ! -d units ]; then
     echo 'Missing units dir'
     mkdir units
   fi
   $FPC @extrafpc.cfg $PROJECT;
-  cd ..
+  popd > /dev/null
 done

--- a/examples/apps/hexviewer/extrafpc.cfg
+++ b/examples/apps/hexviewer/extrafpc.cfg
@@ -1,0 +1,10 @@
+-FUunits
+-Fu../../../lib/$fpctarget
+-Fi.
+-Xs
+-XX
+-CX
+#ifdef mswindows
+-WG
+#endif
+


### PR DESCRIPTION
1° Add missing configuration file in **hexviewer** example folder.

2° Fix _compileall.sh_. Use **pushd** instead of **cd**. Because after `cd ./ide/src`, `cd ..` doesn't come back to the previous directory.
